### PR TITLE
Get validationErrors from response

### DIFF
--- a/SimpleBlazorWASM/SimpleBlazorWASM.Client/RiaServices/Core/WebApiDomainClient.cs
+++ b/SimpleBlazorWASM/SimpleBlazorWASM.Client/RiaServices/Core/WebApiDomainClient.cs
@@ -311,7 +311,7 @@ namespace OpenRiaServices.Client.PortableWeb
                 {
                     var Content = response.Content.ReadAsStringAsync().Result;
                     if (!Content.Contains("DomainServiceFault"))
-                        throw new DomainOperationException(message, OperationErrorStatus.ServerError, (int)response.StatusCode, null);
+                         throw new DomainOperationException(message, OperationErrorStatus.ServerError, (int)response.StatusCode, null);
                 }
             }
 

--- a/SimpleBlazorWASM/SimpleBlazorWASM.Client/RiaServices/Core/WebApiDomainClient.cs
+++ b/SimpleBlazorWASM/SimpleBlazorWASM.Client/RiaServices/Core/WebApiDomainClient.cs
@@ -308,7 +308,11 @@ namespace OpenRiaServices.Client.PortableWeb
                 else if (response.StatusCode == HttpStatusCode.Unauthorized)
                     throw new DomainOperationException(message, OperationErrorStatus.Unauthorized, (int)response.StatusCode, null);
                 else
-                    throw new DomainOperationException(message, OperationErrorStatus.ServerError, (int)response.StatusCode, null);
+                {
+                    var Content = response.Content.ReadAsStringAsync().Result;
+                    if (!Content.Contains("DomainServiceFault"))
+                        throw new DomainOperationException(message, OperationErrorStatus.ServerError, (int)response.StatusCode, null);
+                }
             }
 
             var streamTask = response.Content.ReadAsStreamAsync();


### PR DESCRIPTION
When Invoke operation returned some validation errors, we must deserialize it to `FaultException<RiaServiceBase.DomainServiceFault>` 